### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 
 # dev files
 docs/developmentNotes.md
+
+# manuscript analyses
+manuscript/

--- a/docs/developmentNotes.md
+++ b/docs/developmentNotes.md
@@ -2068,3 +2068,5 @@ earlGreyParTEA \
   -t 8 \
   --slurm
 ```
+
+The many genomes test passed with no errors, and all expected outputs were produced. The shared/unique plots show the 10 species in the same order as the tree, and the BUSCO vs TE QC plot shows points coloured by dominant TE class. This confirms that all new features work together as expected on a larger dataset.

--- a/earlGreyParTEA
+++ b/earlGreyParTEA
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA - Pangenome TE Analysis Pipeline (Full Mode)
-# Version 0.1.3
+# Version 0.1.6
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e

--- a/earlGreyParTEA_AnnotationOnly
+++ b/earlGreyParTEA_AnnotationOnly
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_AnnotationOnly - Pangenome TE Analysis Pipeline (Annotation Only Mode)
-# Version 0.1.3
+# Version 0.1.6
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e

--- a/earlGreyParTEA_LibConstruct
+++ b/earlGreyParTEA_LibConstruct
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_LibConstruct - Pangenome TE Analysis Pipeline (Library Construction Mode)
-# Version 0.1.3
+# Version 0.1.6
 # A Snakemake-based multi-genome transposable element library construction pipeline
 
 set -e

--- a/rules/annotate.smk
+++ b/rules/annotate.smk
@@ -85,30 +85,41 @@ rule merge_repeats:
         """
         mkdir -p {params.outdir}
         
-        # Try loose merge first
+        # Try loose merge first.
+        # Use '|| true' so Snakemake's set -euo pipefail does not abort the shell
+        # block on a non-zero exit from rcMergeRepeatsLoose (e.g. when LTR_FINDER
+        # fails on a particular genome). Fallback logic checks file existence,
+        # mirroring the behaviour of the earlGrey standalone script.
         {params.script_dir}/rcMergeRepeatsLoose -f {input.genome} -s {wildcards.species} \
             -d {params.outdir} -u {input.out} -q {input.tbl} -t {threads} \
-            -b {input.dict} -m {params.margin} {params.helitron_param}
+            -b {input.dict} -m {params.margin} {params.helitron_param} || true
         
-        # Fix GFF formatting
+        # Fix GFF formatting if loose merge succeeded
         if [ -f "{output.gff}" ]; then
             awk '{{OFS="\t"}}{{print $1, $2, $3, $4, $5, $6, $7, $8, toupper($9)}}' {output.gff} > {output.gff}.tmp
             mv {output.gff}.tmp {output.gff}
         fi
         
-        # If loose merge failed, try strict merge
+        # If loose merge did not produce the expected BED, try strict merge
         if [ ! -f "{output.bed}" ]; then
-            echo "Loose merge failed, trying strict merge..."
+            echo "[WARNING] Loose merge did not produce output for {wildcards.species}, trying strict merge..."
             {params.script_dir}/rcMergeRepeats -f {input.genome} -s {wildcards.species} \
                 -d {wildcards.outdir}/{wildcards.species}_EarlGrey/{wildcards.species}_mergedRepeats \
                 -u {input.out} -q {input.tbl} -t {threads} \
-                -b {input.dict} -m {params.margin} {params.helitron_param}
+                -b {input.dict} -m {params.margin} {params.helitron_param} || true
             
-            # Move strict merge results to expected location if loose merge failed
+            # Move strict merge results into the looseMerge location expected by downstream rules
             if [ -f "{wildcards.outdir}/{wildcards.species}_EarlGrey/{wildcards.species}_mergedRepeats/{wildcards.species}.filteredRepeats.bed" ]; then
                 mkdir -p {params.outdir}
                 mv {wildcards.outdir}/{wildcards.species}_EarlGrey/{wildcards.species}_mergedRepeats/{wildcards.species}.filteredRepeats.* {params.outdir}/
             fi
+        fi
+        
+        # Final check — fail with a clear message if neither merge produced output
+        if [ ! -f "{output.bed}" ]; then
+            echo "[ERROR] Both loose and strict merge failed for {wildcards.species}."
+            echo "        Check the RepeatMasker .out file: {input.out}"
+            exit 1
         fi
         """
 


### PR DESCRIPTION
This pull request updates the earlGreyParTEA pipeline scripts and documentation, focusing on improving the robustness of the repeat merging step and updating versioning information. The most significant change is a more fault-tolerant approach to merging repeats, ensuring the pipeline continues even if certain tools fail, and providing clearer error messages for debugging.

**Pipeline robustness and error handling:**

* Improved the `merge_repeats` rule in `rules/annotate.smk` to make the loose merge step non-fatal if it fails (using `|| true`), added logic to check for output existence, and provided a fallback to strict merge with clear warning and error messages if both merges fail. This mirrors the behavior of the standalone earlGrey script and makes debugging easier.

**Version updates:**

* Updated version numbers in the main pipeline scripts (`earlGreyParTEA`, `earlGreyParTEA_LibConstruct`, and `earlGreyParTEA_AnnotationOnly`) from 0.1.3 to 0.1.6 to reflect recent changes. [[1]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cL4-R4) [[2]](diffhunk://#diff-30351e4977331440c60f7202c50e908d9484ecff039cec56936d203c41d16bf5L4-R4) [[3]](diffhunk://#diff-a8a329cf71e149731c75ba7fb5f07372a84bb032af18df368cb39cb6c8f66654L4-R4)

**Documentation improvements:**

* Added a note to `docs/developmentNotes.md` confirming that new features work as expected on a larger dataset, including successful output and correct plot generation.