### PR TITLE
Improve SLURM documentation and enhance logging in ParTEA pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,51 @@ ParTEA extends EarlGrey with features designed for multi-genome comparative TE a
 - 🖥️ **SLURM Cluster Submission** *(new in v0.1.5)* — Pass `--slurm --slurm-partition <partition>` to dispatch each rule as an individual `sbatch` job via `snakemake-executor-plugin-slurm`. Per-job CPUs, memory, and wall-time are declared in each rule and enforced by SLURM. Concurrency is controlled by `--slurm-jobs` rather than `--threads`.
 - 🔀 **Shared/Unique TE Content** *(new in v0.1.6)* — Optional module (`run_shared_unique: true`) that produces stacked bar charts identifying which TE families are core (shared across all genomes), partially shared, or unique to individual genomes. In full pipeline mode, uses cd-hit cluster membership for accurate cross-genome comparison. Optionally reordered by species tree.
 - 🌳 **BUSCO Phylogenomics** *(new in v0.1.6)* — Optional module (`run_busco_phylo: true`) that runs BUSCO, aligns and trims single-copy orthologues, concatenates a supermatrix, and infers a species tree with FastTree. Outputs a phylo-ordered BUSCO completeness chart with cladogram sidebar and a TE content vs BUSCO QC scatter plot.
+- 📋 **Per-rule log files** *(new in v0.1.7)* — Every rule now writes its tool output to a dedicated log file placed alongside its output directory. Only Snakemake progress messages are printed to the terminal during a run; all RepeatMasker, RepeatModeler, HELIANO, and other tool output is captured in per-rule logs for easier post-hoc debugging.
+- 🛡️ **RepeatModeler small-genome robustness** *(improved in v0.1.7)* — The pipeline now computes the samplable genome size (contigs ≥ 40 kb only) and automatically sets `-genomeSampleSizeMax` to prevent RepeatModeler from attempting a round for which insufficient unmasked sequence remains. See [Troubleshooting](#troubleshooting) for details.
 
 ---
 
-## 🆕 Changes in Latest Release (v0.1.6)
+## 🆕 Changes in Latest Release (v0.1.7)
+
+### Per-rule log files
+
+All rules across all six rule files now write their tool output to a dedicated log file placed alongside the relevant output directory (e.g. `{species}.repeatmodeler.log` next to `{species}_RepeatModeler/`). Only Snakemake's own job progress messages are printed to the terminal during a run.
+
+This makes it much easier to locate warnings or diagnose failures after a run without scrolling through thousands of lines of mixed terminal output.
+
+### RepeatModeler small-genome robustness
+
+RepeatModeler can crash on small or fragmented genomes when a later round tries to sample more sequence than is available. The pipeline now prevents this by:
+
+1. Computing the **samplable genome size** — the sum of all contig lengths ≥ 40 kb (RepeatModeler discards shorter contigs during sampling, so the total genome size overestimates what is available).
+2. Setting `-genomeSampleSizeMax` to the per-round sample size for the highest RECON round the genome can support, based on cumulative sample totals across rounds:
+
+| Samplable size | `-genomeSampleSizeMax` | Rounds run |
+|---|---|---|
+| ≥ 363 Mbp | none (default) | 1–6 |
+| ≥ 120 Mbp | `81000000` | 1–5 |
+| ≥ 39 Mbp | `27000000` | 1–4 |
+| ≥ 12 Mbp | `9000000` | 1–3 |
+| < 12 Mbp | `3000000` | 1–2 |
+
+### Extended `repeatmasker_warmup` — species-specific cache
+
+When `repeatmasker_species` is set, RepeatMasker must build a species-specific BLAST database cache before any genome jobs start. Previously this cache was built by the first parallel genome job; if multiple jobs started simultaneously each would attempt to build it and all but one would fail. The warmup rule now pre-builds this cache serially before any per-genome jobs are dispatched.
+
+The warmup also detects and repairs incomplete caches left by a previous OOM-killed run (which can cause all subsequent jobs to crash even though the BLAST database files appear to exist).
+
+### Removal of `-norna` flag
+
+The `-norna` flag was removed from all RepeatMasker calls. This flag suppressed masking of RNA-derived repeats (snRNA, scRNA, tRNA, SINEs); removing it ensures these legitimate TE families are included in the annotation.
+
+---
+
+## Previous Release (v0.1.6)
 
 ### New optional modules
 
-Two new analysis modules are available (both disabled by default):
+Two new analysis modules were added (both disabled by default):
 
 | Module | Config key | Description |
 |--------|-----------|-------------|
@@ -104,7 +141,7 @@ behaviour of `--generate-config` is unchanged.
 - [What is ParTEA?](#what-is-partea)
 - [Citation](#-citation)
 - [ParTEA Features](#-partea-features)
-- [Changes in Latest Release](#-changes-in-latest-release-v016)
+- [Changes in Latest Release](#-changes-in-latest-release-v017)
 - [Pipeline Overview](#-pipeline-overview)
 - [Installation](#-installation)
   - [Via conda/mamba](#via-condamamba-recommended---party-in-a-package)
@@ -889,7 +926,7 @@ Or follow the manual configuration steps in the [Installation](#-installation) s
 
 - Fresh EarlGrey installations only include Dfam partition 0 (minimal database)
 - Full TE annotation requires partitions 0-16 for comprehensive coverage
-- The download is ~10GB and takes time, so it's not included by default
+- The download is HUGE (hundreds of GB) and takes time, so it's not included by default
 
 **After configuring:**
 
@@ -961,6 +998,34 @@ For conda installations, this is typically:
 ```yaml
 script_dir: "$CONDA_PREFIX/share/earlgrey-7.1.0-0/scripts"  # Adjust version
 ```
+
+### RepeatModeler crashes with "FastaDB::compact - Error could not locate file"
+
+This error occurs when RepeatModeler tries to start a new sampling round but the genome has already been exhausted in previous rounds:
+
+```
+FastaDB::compact - Error could not locate file .../round-4/sampleDB-4.fa!
+```
+
+RepeatModeler decides whether to continue to the next round, but does not check whether there is enough remaining unmasked sequence to sample. On small or highly fragmented genomes, the genome can be exhausted before the final round.
+
+**From v0.1.7, ParTEA automatically prevents this** by setting `-genomeSampleSizeMax` based on the samplable genome size (contigs ≥ 40 kb only; shorter contigs are discarded by RepeatModeler internally). The per-round sample sizes accumulate across rounds:
+
+| Cumulative sample needed | `-genomeSampleSizeMax` set | Rounds run |
+|---|---|---|
+| ≥ 363 Mbp samplable | none (RepeatModeler default) | 1–6 |
+| ≥ 120 Mbp samplable | `81000000` | 1–5 |
+| ≥ 39 Mbp samplable | `27000000` | 1–4 |
+| ≥ 12 Mbp samplable | `9000000` | 1–3 |
+| < 12 Mbp samplable | `3000000` | 1–2 |
+
+**If you see this error on v0.1.6 or earlier**, upgrade to v0.1.7. If you need to rerun a genome that crashed mid-run, clean the RepeatModeler working directory first:
+
+```bash
+rm -rf {output_dir}/{species}_EarlGrey/{species}_RepeatModeler/
+```
+
+Then rerun with `--rerun-incomplete`.
 
 ### DAG visualization not generated
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "earlgrey-partea" %}
-{% set version = "0.1.7.dev" %}
+{% set version = "0.1.7" %}
 
 package:
   name: {{ name|lower }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  git_url: ".."
-  git_rev: HEAD
+  url: https://github.com/TobyBaril/EarlGreyParTEA/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: REPLACE_WITH_RELEASE_TARBALL_SHA256
 
 build:
   number: 0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,12 +1,13 @@
 {% set name = "earlgrey-partea" %}
-{% set version = "0.1.6" %}
+{% set version = "0.1.7.dev" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  path: ..
+  git_url: ".."
+  git_rev: HEAD
 
 build:
   number: 0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -74,6 +74,6 @@ busco_min_occupancy: 0.5  # Min fraction of species a BUSCO gene must be in to b
 # script_dir: "/path/to/earlgrey/scripts"  # Auto-detected if installed via conda/mamba
 
 # SLURM cluster settings (only used with --slurm flag)
-slurm_partition: ""   # partition/queue to submit to (required with --slurm)
+slurm_partition: ""   # partition/queue to submit to (required when using --slurm; can be set here instead of --slurm-partition)
 slurm_account: ""     # account string (leave empty if not required)
 slurm_extra: ""       # any extra sbatch flags, e.g. "--constraint=avx2"

--- a/docs/developmentNotes.md
+++ b/docs/developmentNotes.md
@@ -2124,14 +2124,120 @@ The warmup `mem_mb` was increased from 4,000 to 32,000 MB and `runtime` from 30 
 
 ### RepeatModeler robustness for small genomes (`-genomeSampleSizeMax`)
 
-**Problem:** RepeatModeler builds consensus sequences through iterative rounds of BLAST searches against an unmasked sample of the genome. In each round it draws a random sample of up to 81 Mbp (the default `genomeSampleSizeMax`). For genomes smaller than this threshold, and particularly in later rounds where much of the genome has been masked, RepeatModeler may fail because there are insufficient unmasked bases to generate any sample at all. The error typically appears as an exit-code-1 failure deep inside a RepeatModeler round with no informative message.
+**Problem:** RepeatModeler runs up to 6 rounds of repeat discovery. Round 1 uses RepeatScout and samples up to 40 Mbp; rounds 2–6 use RECON with progressively larger samples:
 
-**Fix:** Added a genome-size check at the start of the `repeatmodeler` shell block. The genome BLAST database created by `build_db` is queried with `blastdbcmd -info`, which returns the total number of bases. If the total is below 81,000,000 bp, `-genomeSampleSizeMax <size>` is appended to the RepeatModeler command, capping the sample target to the actual genome size so RepeatModeler can always find enough sequence to proceed.
+| Round | Tool | Sample size |
+|-------|------|-------------|
+| 1 | RepeatScout | 40 Mbp |
+| 2 | RECON | 3 Mbp |
+| 3 | RECON | 9 Mbp |
+| 4 | RECON | 27 Mbp |
+| 5 | RECON | 81 Mbp |
+| 6 | RECON | 243 Mbp |
 
-The check uses the existing BLAST database (which RepeatModeler requires as input anyway) and adds no extra files or steps. Three guard conditions are applied before the comparison — non-empty result, numeric-only string, integer comparison — so that any unexpected `blastdbcmd` output causes the check to be silently skipped rather than aborting the job.
+For genomes smaller than the round 6 default, RepeatModeler may attempt a round for which there is insufficient unmasked sequence (because earlier rounds have already masked much of the genome). When this happens it fails to write the round's `sampleDB-N.fa` file and crashes with:
+
+```
+FastaDB::compact - Error could not locate file .../round-N/sampleDB-N.fa!
+ at .../RepeatModeler line 943.
+```
+
+This is a RepeatModeler bug — it should exit gracefully — but the pipeline must handle it.
+
+**Complication — contigs < 40 kb are discarded:** RepeatModeler discards any contig shorter than 40 kb during sampling. Using the total genome size from the BLAST database (`blastdbcmd -info`) overestimates the sequence actually available. The correct value is the sum of all contig lengths ≥ 40 kb.
+
+**Fix:** The `repeatmodeler` rule now:
+
+1. Computes the **sampable genome size** — sum of contig lengths ≥ 40 kb — from the `.prep` FASTA using an awk one-liner (the `.prep` file is already an explicit rule input):
+
+```bash
+GENOME_SIZE=$(awk '/^>/{if(len>=40000)sum+=len; len=0; next}{len+=length($0)} \
+    END{if(len>=40000)sum+=len; print sum+0}' {input.prep})
+```
+
+2. Selects the highest RECON round the genome can support by comparing the sampable size against **cumulative** sample totals across rounds (since a genome must have enough sequence for all rounds up to and including the cap, not just the final one):
+
+| Sampable size | `-genomeSampleSizeMax` | Rounds run |
+|---|---|---|
+| ≥ 363 Mbp (3+9+27+81+243) | none (default) | 1–6 |
+| ≥ 120 Mbp (3+9+27+81) | `81000000` | 1–5 |
+| ≥ 39 Mbp (3+9+27) | `27000000` | 1–4 |
+| ≥ 12 Mbp (3+9) | `9000000` | 1–3 |
+| < 12 Mbp | `3000000` | 1–2 |
+
+The `-genomeSampleSizeMax` value itself is set to the per-round size for the final allowed round (not the cumulative total), matching RepeatModeler's internal semantics for the flag.
+
+**Example (Neuro73, ~38.7 Mbp sampable):** `39M > 38.7M`, so the cap is `27000000` → rounds 1–4 only. Without the fix RepeatModeler ran all 4 RECON rounds successfully then attempted round 5, could not build `sampleDB-4.fa` from the exhausted masked genome, and crashed.
 
 **Files changed:**
-- `rules/lib_construct.smk` — added `blastdbcmd -info` size check and conditional `SAMPLE_FLAG` in `repeatmodeler` shell block
+- `rules/lib_construct.smk` — added `.prep` as an explicit input to `repeatmodeler`; awk sampable-size calculation; round-capping logic with cumulative thresholds
+
+---
+
+### Per-rule log files (all rules)
+
+**Motivation:** Previously only a small number of rules had `log:` directives. All tool output (RepeatMasker, RepeatModeler, HELIANO, etc.) was printed to stdout/stderr and mixed with Snakemake's own progress messages. On long runs this made it hard to locate warnings or diagnose failures without scrolling through thousands of lines.
+
+**Changes:** A `log:` directive was added to every rule across all six rule files:
+
+| File | Rules modified |
+|------|---------------|
+| `rules/lib_construct.smk` | `repeatmasker_warmup`, `prep_genome`, `repeatmasker`, `repeatmasker_custom`, `extract_repeatmasker_library`, `build_db`, `repeatmodeler`, `testrainer` |
+| `rules/annotate.smk` | `repeatmasker_annotation`, `heliano_detection`, `merge_repeats`, `generate_summary_charts`, `calculate_divergence`, `sweep_up_files`, `generate_softmasked_genome` |
+| `rules/busco_phylo.smk` | `fetch_busco_db`, `run_busco`, `busco_summary_table`, `extract_busco_aa`, `align_busco_gene`, `create_supermatrix`, `run_fasttree`, `busco_completeness_phylo`, `busco_te_qc` |
+| `rules/saturation.smk` | `saturation_plot` |
+| `rules/clustering.smk` | `cluster_all_species` |
+| `rules/shared_unique_content.smk` | `shared_unique_plot`, `shared_unique_plot_phylo`, `shared_unique_pa_plot`, `shared_unique_pa_plot_phylo` |
+
+**Log file placement:** Log files sit alongside their output directories, using the same wildcard structure as the rule's `output:` block. Example paths:
+
+- `{outdir}/{species}_EarlGrey/{species}_RepeatModeler/{species}.repeatmodeler.log`
+- `{outdir}/{species}_EarlGrey/{species}_RepeatMasker/{species}.repeatmasker.log`
+- `{outdir}/{species}_EarlGrey/{species}_heliano/{species}.heliano_detection.log`
+- `{OUTDIR}/combinedLibraries/cluster_all_species.log`
+- `{OUTDIR}/buscoPhylo/fasttree.log`
+
+**Shell output redirection strategy:**
+
+- `shell:` rules: `exec > {log} 2>&1` as the first line redirects all subsequent stdout and stderr (including subprocesses) to the log file.
+- `script:` rules: Snakemake automatically redirects stderr to the `log:` file; no extra line is needed.
+- `run:` rules: each `shell()` call appends `>> str(log) + " 2>&1"`.
+- **Special case — `run_fasttree`:** FastTree writes the newick tree to stdout and diagnostics to stderr, so `FastTree ... > {output.tree} 2>> {log}` is used instead of `exec > {log} 2>&1`.
+
+**Effect:** After this change only Snakemake's job submission/completion messages and explicit `print()` calls in `on_start_functions.py` appear on the terminal. All tool output is captured in per-rule log files.
+
+**Files changed:**
+- `rules/lib_construct.smk`, `rules/annotate.smk`, `rules/busco_phylo.smk`, `rules/saturation.smk`, `rules/clustering.smk`, `rules/shared_unique_content.smk` — `log:` directives and redirection added to all rules
+
+---
+
+### Bug fix: wildcard mismatch in `clustering.smk`
+
+**Error observed when the log directive was first added:**
+
+```
+WorkflowError: Not all output, log and benchmark files of rule cluster_all_species
+contain the same wildcards. This is a Snakemake requirement.
+```
+
+**Root cause:** The `log:` directive was initially written as a Python f-string:
+
+```python
+log: f"{OUTDIR}/combinedLibraries/cluster_all_species.log"
+```
+
+Because f-strings are evaluated at Python parse time, this produces a literal string that Snakemake's wildcard system cannot see. The rule's `output:` uses the `{outdir}` Snakemake wildcard, so Snakemake's validator correctly rejects the mismatch.
+
+**Fix:** Changed to a plain wildcard string:
+
+```python
+log: "{outdir}/combinedLibraries/cluster_all_species.log"
+```
+
+**General principle:** `log:` must use the same wildcard form as `output:`. If `output:` uses Snakemake wildcards (`{outdir}`, `{species}`, etc.), so must `log:`. Python f-strings in rule fields are only appropriate when `output:` is also an f-string (path fully determined at parse time from global variables like `OUTDIR`).
+
+**Files changed:**
+- `rules/clustering.smk` — `log:` changed from f-string to Snakemake wildcard string
 
 ---
 
@@ -2139,8 +2245,11 @@ The check uses the existing BLAST database (which RepeatModeler requires as inpu
 
 - [ ] Run pipeline with `repeatmasker_species` set on a species with a large library (e.g. Drosophila `7215`). Confirm warmup builds a complete `7215/` cache including `refineableHash.dat` before any parallel genome jobs start.
 - [ ] Manually corrupt the `7215/` cache (delete `refineableHash.dat`, leave `.nhr` files). Re-run. Confirm warmup detects the incomplete cache, removes the directory, and rebuilds it cleanly.
-- [ ] Run pipeline with a genome < 81 Mbp. Confirm RepeatModeler receives `-genomeSampleSizeMax <size>` in the job log (stderr message: `Small genome detected`).
+- [ ] Run pipeline with a genome < 81 Mbp. Confirm RepeatModeler receives `-genomeSampleSizeMax <size>` in the job log.
 - [ ] Run pipeline with a genome > 81 Mbp. Confirm RepeatModeler receives no extra flag.
 - [ ] Confirm no RNA-family annotations appear as masked in RepeatMasker output that would previously have been suppressed by `-norna` (e.g. check for `RNA` or `srpRNA` class entries in `.out` files).
-- [ ] Local mode regression: confirm all three changes do not break a standard local run on a previously working dataset.
+- [ ] After a completed run, confirm per-rule log files exist alongside each output directory (e.g. `{species}.repeatmodeler.log`, `{species}.repeatmasker.log`, `{species}.heliano_detection.log`).
+- [ ] Confirm terminal output during a run shows only Snakemake progress lines and startup messages — no RepeatMasker/RepeatModeler/HELIANO stdout.
+- [ ] Confirm `{OUTDIR}/combinedLibraries/cluster_all_species.log` is created on a multi-genome run (validates the wildcard-string fix).
+- [ ] Local mode regression: confirm all changes do not break a standard local run on a previously working dataset.
 

--- a/docs/developmentNotes.md
+++ b/docs/developmentNotes.md
@@ -2069,4 +2069,78 @@ earlGreyParTEA \
   --slurm
 ```
 
-The many genomes test passed with no errors, and all expected outputs were produced. The shared/unique plots show the 10 species in the same order as the tree, and the BUSCO vs TE QC plot shows points coloured by dominant TE class. This confirms that all new features work together as expected on a larger dataset.
+The many genomes test passed with no errors, and all expected outputs were produced. The shared/unique plots show the 10 species in the same order as the tree, and the BUSCO vs TE QC plot shows points coloured by dominant TE class. This confirms the pipeline is working correctly for v0.1.6.
+
+---
+
+## Release v0.1.7 Feature Updates
+
+### Removal of `-norna` flag from all RepeatMasker calls
+
+**Problem:** All RepeatMasker invocations in the pipeline carried the `-norna` flag, which suppresses masking of small RNA genes and related repeats (snRNA, scRNA, tRNA etc.). This was undesirable for a general-purpose TE annotation pipeline — RNA-derived repeats such as SINEs are legitimate TE families and excluding them from masking introduces a systematic gap in the annotation.
+
+**Fix:** Removed `-norna` from every RepeatMasker call in the pipeline:
+
+- `rules/lib_construct.smk` — removed from `repeatmasker` (species-database initial masking) and `repeatmasker_custom` (custom-library initial masking)
+- `rules/annotate.smk` — removed from `repeatmasker_annotation` (final annotation masking against the curated TE library)
+
+The warmup dummy run (`repeatmasker_warmup`) is not affected because it uses `-lib` with a short random sequence that will never match any annotated repeats regardless of `-norna`.
+
+**Files changed:**
+- `rules/lib_construct.smk`
+- `rules/annotate.smk`
+
+---
+
+### Extended `repeatmasker_warmup` to pre-build species-specific library cache
+
+**Background:** The v0.1.3 `repeatmasker_warmup` rule only pre-built the general RepeatMasker BLAST cache. When a taxon-specific library is requested (e.g. `repeatmasker_species: "7215"` for Drosophila), RepeatMasker must also build a species-specific BLAST database cache at `Libraries/CONS-Dfam_withRBRM_3.9/<species>/` the first time it runs. This cache build writes several files:
+
+- `refineableHash.dat` — a Perl `Storable` hash mapping each TE family to its refinability status
+- `speciesMeta.pm` — Perl module with metadata about the species library
+- `specieslib` + BLAST DB files (`specieslib.nhr`, `.nin`, `.nsq`, etc.) — the BLAST-indexed library
+
+If multiple genome jobs start simultaneously before this cache exists, each job tries to build it in parallel. All jobs create their own `<species>.working/` staging directory, but only one can win the final rename; all others fail immediately.
+
+**Additional complication — incomplete cache from a previous OOM kill:** If a previous run was killed mid-build (e.g. by a SLURM cgroup OOM signal during `makeblastdb`), the `<species>/` directory may be left in a partially-built state containing the BLAST `.nhr`/`.nin`/`.nsq` files but lacking `refineableHash.dat` and `speciesMeta.pm`. RepeatMasker's cache-validation logic checks for `*.nhr` first; if found, it treats the cache as valid and tries to immediately retrieve `refineableHash.dat` with Perl `Storable::retrieve()`. This fails with a crash rather than triggering a rebuild, causing every parallel genome job to fail.
+
+**Root cause of observed failures (April 2026 drosophila run):**
+1. **April 24** — OOM kill during `makeblastdb` building the Drosophila species library (2,541 sequences). Left `7215/` with BLAST DB files only; no `refineableHash.dat`.
+2. **April 30 re-run** — `7215/` had `.nhr` files → RepeatMasker's cache check passed → immediate crash on `retrieve("refineableHash.dat")` for all parallel jobs.
+
+**Fix:** The `repeatmasker_warmup` rule now also pre-builds the species-specific cache before any parallel genome jobs start. The new logic:
+
+1. Checks whether the species cache directory exists but is missing `refineableHash.dat` (incomplete from a previous aborted run). If so, **deletes the directory** to force a fresh build. RepeatMasker will not do this itself because it considers `.nhr` a sufficient validity indicator.
+2. Removes any stale `<species>.working/` directory from a previous aborted parallel build.
+3. Runs a single dummy RepeatMasker job (`-species <spec>` on a one-sequence FASTA) to trigger the full cache build — including `refineableHash.dat`, `speciesMeta.pm`, and the BLAST DB.
+4. **Verifies** that `refineableHash.dat` now exists. If not, the warmup rule exits with a non-zero status and a clear error message, preventing the pipeline from proceeding with a broken cache.
+
+The warmup `mem_mb` was increased from 4,000 to 32,000 MB and `runtime` from 30 to 120 minutes to accommodate the large species library build (the Drosophila `7215` library is ~2,500 sequences and requires a correspondingly large `makeblastdb` run).
+
+**Files changed:**
+- `rules/lib_construct.smk` — extended `repeatmasker_warmup` shell block; added `params: rep_spec=REPSPEC`; increased `mem_mb` and `runtime` resources
+
+---
+
+### RepeatModeler robustness for small genomes (`-genomeSampleSizeMax`)
+
+**Problem:** RepeatModeler builds consensus sequences through iterative rounds of BLAST searches against an unmasked sample of the genome. In each round it draws a random sample of up to 81 Mbp (the default `genomeSampleSizeMax`). For genomes smaller than this threshold, and particularly in later rounds where much of the genome has been masked, RepeatModeler may fail because there are insufficient unmasked bases to generate any sample at all. The error typically appears as an exit-code-1 failure deep inside a RepeatModeler round with no informative message.
+
+**Fix:** Added a genome-size check at the start of the `repeatmodeler` shell block. The genome BLAST database created by `build_db` is queried with `blastdbcmd -info`, which returns the total number of bases. If the total is below 81,000,000 bp, `-genomeSampleSizeMax <size>` is appended to the RepeatModeler command, capping the sample target to the actual genome size so RepeatModeler can always find enough sequence to proceed.
+
+The check uses the existing BLAST database (which RepeatModeler requires as input anyway) and adds no extra files or steps. Three guard conditions are applied before the comparison — non-empty result, numeric-only string, integer comparison — so that any unexpected `blastdbcmd` output causes the check to be silently skipped rather than aborting the job.
+
+**Files changed:**
+- `rules/lib_construct.smk` — added `blastdbcmd -info` size check and conditional `SAMPLE_FLAG` in `repeatmodeler` shell block
+
+---
+
+### Verification checklist for v0.1.7
+
+- [ ] Run pipeline with `repeatmasker_species` set on a species with a large library (e.g. Drosophila `7215`). Confirm warmup builds a complete `7215/` cache including `refineableHash.dat` before any parallel genome jobs start.
+- [ ] Manually corrupt the `7215/` cache (delete `refineableHash.dat`, leave `.nhr` files). Re-run. Confirm warmup detects the incomplete cache, removes the directory, and rebuilds it cleanly.
+- [ ] Run pipeline with a genome < 81 Mbp. Confirm RepeatModeler receives `-genomeSampleSizeMax <size>` in the job log (stderr message: `Small genome detected`).
+- [ ] Run pipeline with a genome > 81 Mbp. Confirm RepeatModeler receives no extra flag.
+- [ ] Confirm no RNA-family annotations appear as masked in RepeatMasker output that would previously have been suppressed by `-norna` (e.g. check for `RNA` or `srpRNA` class entries in `.out` files).
+- [ ] Local mode regression: confirm all three changes do not break a standard local run on a previously working dataset.
+

--- a/earlGreyParTEA
+++ b/earlGreyParTEA
@@ -37,7 +37,8 @@ Optional Parameters:
     --snakemake-args "FLAGS"  Pass additional arguments directly to snakemake (e.g. "--until rule_name")
     --slurm                 Submit jobs to a SLURM cluster via snakemake-executor-plugin-slurm
     --slurm-jobs N          Max concurrent SLURM jobs (default: genomes × 3, capped at 200)
-    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm)
+    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm unless set
+                            as 'slurm_partition:' in the config file)
     --slurm-account ACCT    SLURM account string (optional)
     --slurm-extra "FLAGS"   Additional raw sbatch flags (e.g. "--constraint=avx2")
     -h, --help              Show this help message
@@ -351,7 +352,7 @@ if $SLURM; then
     # --- SLURM mode ---
     # Fall back to SLURM settings from config file if not set via CLI
     if [ -z "$SLURM_PARTITION" ]; then
-        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition', ''))" 2>/dev/null || echo "")
+        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition') or '')" 2>/dev/null || echo "")
     fi
     if [ -z "$SLURM_ACCOUNT" ]; then
         SLURM_ACCOUNT=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_account', ''))" 2>/dev/null || echo "")

--- a/earlGreyParTEA
+++ b/earlGreyParTEA
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA - Pangenome TE Analysis Pipeline (Full Mode)
-# Version 0.1.6
+# Version 0.1.7
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e
 
-VERSION="0.1.6"
+VERSION="0.1.7"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/earlGreyParTEA_AnnotationOnly
+++ b/earlGreyParTEA_AnnotationOnly
@@ -38,7 +38,8 @@ Optional Parameters:
     --snakemake-args "FLAGS"  Pass additional arguments directly to snakemake (e.g. "--until rule_name")
     --slurm                 Submit jobs to a SLURM cluster via snakemake-executor-plugin-slurm
     --slurm-jobs N          Max concurrent SLURM jobs (default: genomes × 3, capped at 200)
-    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm)
+    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm unless set
+                            as 'slurm_partition:' in the config file)
     --slurm-account ACCT    SLURM account string (optional)
     --slurm-extra "FLAGS"   Additional raw sbatch flags (e.g. "--constraint=avx2")
     -h, --help              Show this help message
@@ -348,7 +349,7 @@ if $SLURM; then
     # --- SLURM mode ---
     # Fall back to SLURM settings from config file if not set via CLI
     if [ -z "$SLURM_PARTITION" ]; then
-        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition', ''))" 2>/dev/null || echo "")
+        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition') or '')" 2>/dev/null || echo "")
     fi
     if [ -z "$SLURM_ACCOUNT" ]; then
         SLURM_ACCOUNT=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_account', ''))" 2>/dev/null || echo "")

--- a/earlGreyParTEA_AnnotationOnly
+++ b/earlGreyParTEA_AnnotationOnly
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_AnnotationOnly - Pangenome TE Analysis Pipeline (Annotation Only Mode)
-# Version 0.1.6
+# Version 0.1.7
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e
 
-VERSION="0.1.6"
+VERSION="0.1.7"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/earlGreyParTEA_LibConstruct
+++ b/earlGreyParTEA_LibConstruct
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_LibConstruct - Pangenome TE Analysis Pipeline (Library Construction Mode)
-# Version 0.1.6
+# Version 0.1.7
 # A Snakemake-based multi-genome transposable element library construction pipeline
 
 set -e
 
-VERSION="0.1.6"
+VERSION="0.1.7"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/earlGreyParTEA_LibConstruct
+++ b/earlGreyParTEA_LibConstruct
@@ -38,7 +38,8 @@ Optional Parameters:
     --snakemake-args "FLAGS"  Pass additional arguments directly to snakemake (e.g. "--until rule_name")
     --slurm                 Submit jobs to a SLURM cluster via snakemake-executor-plugin-slurm
     --slurm-jobs N          Max concurrent SLURM jobs (default: genomes × 3, capped at 200)
-    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm)
+    --slurm-partition PART  SLURM partition/queue to submit to (required with --slurm unless set
+                            as 'slurm_partition:' in the config file)
     --slurm-account ACCT    SLURM account string (optional)
     --slurm-extra "FLAGS"   Additional raw sbatch flags (e.g. "--constraint=avx2")
     -h, --help              Show this help message
@@ -355,7 +356,7 @@ if $SLURM; then
     # --- SLURM mode ---
     # Fall back to SLURM settings from config file if not set via CLI
     if [ -z "$SLURM_PARTITION" ]; then
-        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition', ''))" 2>/dev/null || echo "")
+        SLURM_PARTITION=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_partition') or '')" 2>/dev/null || echo "")
     fi
     if [ -z "$SLURM_ACCOUNT" ]; then
         SLURM_ACCOUNT=$(python3 -c "import yaml; cfg=yaml.safe_load(open('$CONFIG')); print(cfg.get('slurm_account', ''))" 2>/dev/null || echo "")

--- a/rules/annotate.smk
+++ b/rules/annotate.smk
@@ -19,6 +19,8 @@ rule repeatmasker_annotation:
         masked="{outdir}/{species}_EarlGrey/{species}_RepeatMasker_Against_Custom_Library/{species}.prep.masked",
         out="{outdir}/{species}_EarlGrey/{species}_RepeatMasker_Against_Custom_Library/{species}.prep.out",
         tbl="{outdir}/{species}_EarlGrey/{species}_RepeatMasker_Against_Custom_Library/{species}.prep.tbl"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_RepeatMasker_Against_Custom_Library/{species}.repeatmasker_annotation.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 64)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 64))
     resources:
         mem_mb=lambda wildcards, attempt: 16000 * attempt,
@@ -28,6 +30,7 @@ rule repeatmasker_annotation:
         rm_threads=lambda wildcards, threads: max(1, threads // 4)  # RepeatMasker -pa value (uses 4x this)
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         RepeatMasker -lib $(realpath {input.library}) -no_is -lcambig -s -a \
@@ -39,6 +42,8 @@ rule heliano_detection:
         genome="{outdir}/{species}_EarlGrey/{species}.prep"
     output:
         helitron_gff="{outdir}/{species}_EarlGrey/{species}_heliano/RC.representative.gff"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_heliano/{species}.heliano_detection.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 32)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 32))
     resources:
         mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -47,6 +52,7 @@ rule heliano_detection:
         heliano_dir="{outdir}/{species}_EarlGrey/{species}_heliano"
     shell:
         """
+        exec > {log} 2>&1
         if [ "{HELIANO}" == "yes" ]; then
             mkdir -p {params.heliano_dir}
             cd {params.heliano_dir}
@@ -72,6 +78,8 @@ rule merge_repeats:
         bed="{outdir}/{species}_EarlGrey/{species}_mergedRepeats/looseMerge/{species}.filteredRepeats.bed",
         gff="{outdir}/{species}_EarlGrey/{species}_mergedRepeats/looseMerge/{species}.filteredRepeats.gff",
         summary="{outdir}/{species}_EarlGrey/{species}_mergedRepeats/looseMerge/{species}.filteredRepeats.summary"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_mergedRepeats/{species}.merge_repeats.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 16)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 16))
     resources:
         mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -83,6 +91,7 @@ rule merge_repeats:
         helitron_param=lambda wildcards, input: f"-e {input.helitron_gff}" if HELIANO == "yes" and os.path.getsize(input.helitron_gff if HELIANO == "yes" else "/dev/null") > 0 else ""
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         
         # Try loose merge first.
@@ -130,6 +139,8 @@ rule generate_summary_charts:
     output:
         pie="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.summaryPie.pdf",
         highLevelCount="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.highLevelCount.txt"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.generate_summary_charts.log"
     threads: 1
     resources:
         mem_mb=4000,
@@ -139,6 +150,7 @@ rule generate_summary_charts:
         outdir="{outdir}/{species}_EarlGrey/{species}_summaryFiles"
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         {params.script_dir}/autoPie.sh -i {input.summary} -t {input.tbl} \
@@ -153,6 +165,8 @@ rule calculate_divergence:
     output:
         div_gff="{outdir}/{species}_EarlGrey/{species}_RepeatLandscape/{species}.filteredRepeats.withDivergence.gff",
         div_summary="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}_divergence_summary_table.tsv"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_RepeatLandscape/{species}.calculate_divergence.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 16)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 16))
     resources:
         mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -164,6 +178,7 @@ rule calculate_divergence:
         divcalc_tmp="/tmp/egdiv_{species}",
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.landscape_dir}
         cd {params.landscape_dir}
         
@@ -205,6 +220,8 @@ rule sweep_up_files:
     output:
         summary_bed="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.filteredRepeats.bed",
         summary_gff="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.filteredRepeats.gff"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.sweep_up_files.log"
     threads: 1
     resources:
         mem_mb=2000,
@@ -213,6 +230,7 @@ rule sweep_up_files:
         summary_dir="{outdir}/{species}_EarlGrey/{species}_summaryFiles"
     shell:
         """
+        exec > {log} 2>&1
         # Copy final results to summary directory
         cp {input.bed} {output.summary_bed}
         cp {input.gff} {output.summary_gff}
@@ -224,12 +242,15 @@ rule generate_softmasked_genome:
         backup="{outdir}/{species}_EarlGrey/{species}.bak.gz"
     output:
         softmasked="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.softmasked.fasta"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}.generate_softmasked_genome.log"
     threads: 1
     resources:
         mem_mb=8000,
         runtime=60
     shell:
         """
+        exec > {log} 2>&1
         if [ "{SOFTMASK}" == "yes" ]; then
             gunzip -c {input.backup} > {input.backup}.tmp
             bedtools maskfasta -fi {input.backup}.tmp -bed {input.bed} \

--- a/rules/annotate.smk
+++ b/rules/annotate.smk
@@ -30,7 +30,7 @@ rule repeatmasker_annotation:
         """
         mkdir -p {params.outdir}
         cd {params.outdir}
-        RepeatMasker -lib $(realpath {input.library}) -norna -no_is -lcambig -s -a \
+        RepeatMasker -lib $(realpath {input.library}) -no_is -lcambig -s -a \
             -pa {params.rm_threads} -dir {params.outdir} $(realpath {input.genome})
         """
 

--- a/rules/busco_phylo.smk
+++ b/rules/busco_phylo.smk
@@ -38,6 +38,8 @@ rule fetch_busco_db:
     in parallel."""
     output:
         sentinel=f"{OUTDIR}/buscoPhylo/.busco_db_ready",
+    log:
+        f"{OUTDIR}/buscoPhylo/fetch_busco_db.log"
     params:
         lineage=BUSCO_LINEAGE,
         db_path=f"{OUTDIR}/buscoPhylo/busco_db",
@@ -47,6 +49,7 @@ rule fetch_busco_db:
         runtime=120,
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.db_path}
         busco --download {params.lineage} --download_path {params.db_path}
         touch {output.sentinel}
@@ -64,6 +67,8 @@ rule run_busco:
     output:
         summary=f"{{outdir}}/{{species}}_EarlGrey/{{species}}_busco/short_summary.specific.{BUSCO_LINEAGE}.{{species}}_busco.txt",
         busco_dir=directory("{outdir}/{species}_EarlGrey/{species}_busco"),
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_busco/{species}.run_busco.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 16)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 16))
     resources:
         mem_mb=lambda wildcards, attempt: 16000 * attempt,
@@ -75,6 +80,7 @@ rule run_busco:
         db_path=f"{OUTDIR}/buscoPhylo/busco_db",
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         busco \
@@ -104,6 +110,8 @@ rule busco_summary_table:
     output:
         pdf=f"{OUTDIR}/buscoPhylo/busco_completeness.pdf",
         tsv=f"{OUTDIR}/buscoPhylo/busco_completeness.tsv",
+    log:
+        f"{OUTDIR}/buscoPhylo/busco_summary_table.log"
     threads: 1
     resources:
         mem_mb=4000,
@@ -128,6 +136,8 @@ checkpoint extract_busco_aa:
     output:
         gene_dir=directory(f"{OUTDIR}/buscoPhylo/busco_genes"),
         occupancy_tsv=f"{OUTDIR}/buscoPhylo/busco_gene_occupancy.tsv",
+    log:
+        f"{OUTDIR}/buscoPhylo/extract_busco_aa.log"
     threads: 1
     resources:
         mem_mb=4000,
@@ -150,12 +160,15 @@ rule align_busco_gene:
         faa=f"{OUTDIR}/buscoPhylo/busco_genes/{{gene_id}}.faa",
     output:
         aln=f"{OUTDIR}/buscoPhylo/aligned/{{gene_id}}.clipkit.fa",
+    log:
+        f"{OUTDIR}/buscoPhylo/aligned/{{gene_id}}.align.log"
     threads: 1
     resources:
         mem_mb=2000,
         runtime=30,
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p $(dirname {output.aln})
         mafft --auto --quiet {input.faa} > {output.aln}.mafft.fa
         clipkit {output.aln}.mafft.fa -m smart-gap -o {output.aln}
@@ -191,6 +204,8 @@ rule create_supermatrix:
     output:
         supermatrix=f"{OUTDIR}/buscoPhylo/supermatrix.fa",
         partition=f"{OUTDIR}/buscoPhylo/supermatrix.partitions",
+    log:
+        f"{OUTDIR}/buscoPhylo/create_supermatrix.log"
     threads: 1
     resources:
         mem_mb=8000,
@@ -272,6 +287,8 @@ rule run_fasttree:
         supermatrix=f"{OUTDIR}/buscoPhylo/supermatrix.fa",
     output:
         tree=f"{OUTDIR}/buscoPhylo/species_tree.nwk",
+    log:
+        f"{OUTDIR}/buscoPhylo/fasttree.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 8))
     resources:
         mem_mb=lambda wildcards, attempt: 16000 * attempt,
@@ -279,7 +296,7 @@ rule run_fasttree:
     shell:
         """
         export OMP_NUM_THREADS={threads}
-        FastTree -lg -gamma {input.supermatrix} > {output.tree} 2>>{output.tree}.log
+        FastTree -lg -gamma {input.supermatrix} > {output.tree} 2>> {log}
         """
 
 
@@ -293,6 +310,8 @@ rule busco_completeness_phylo:
         tree=f"{OUTDIR}/buscoPhylo/species_tree.nwk",
     output:
         pdf=f"{OUTDIR}/buscoPhylo/busco_completeness_phylo.pdf",
+    log:
+        f"{OUTDIR}/buscoPhylo/busco_completeness_phylo.log"
     threads: 1
     resources:
         mem_mb=2000,
@@ -320,6 +339,8 @@ rule busco_te_qc:
     output:
         pdf=f"{OUTDIR}/buscoPhylo/busco_te_qc.pdf",
         tsv=f"{OUTDIR}/buscoPhylo/busco_te_qc.tsv",
+    log:
+        f"{OUTDIR}/buscoPhylo/busco_te_qc.log"
     threads: 1
     resources:
         mem_mb=4000,

--- a/rules/clustering.smk
+++ b/rules/clustering.smk
@@ -7,6 +7,8 @@ rule cluster_all_species:
     output:
         combined="{outdir}/combinedLibraries/combined_all_species.clstrd.fa",
         clstr="{outdir}/combinedLibraries/combined_all_species.clstrd.fa.clstr"
+    log:
+        "{outdir}/combinedLibraries/cluster_all_species.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 32))  # cd-hit: scales 1-32 threads (single job, runs once)
     resources:
         mem_mb=lambda wildcards, attempt: 32000 * attempt,
@@ -20,7 +22,7 @@ rule cluster_all_species:
         cluster_coverage=config.get("clustering_coverage", 0.8)
     run:
         import os
-        shell("mkdir -p {params.outdir}/combinedLibraries")
+        shell("mkdir -p {params.outdir}/combinedLibraries >> " + str(log) + " 2>&1")
         
         # Define combined file path
         combined_file = f"{params.outdir}/combinedLibraries/combined_all_species.fa"
@@ -57,22 +59,22 @@ rule cluster_all_species:
         # Cluster or skip based on config
         if params.skip_clustering:
             # Just copy/rename the combined file as the output (no clustering)
-            shell(f"cp {combined_file} {{output.combined}}")
-            shell(f"rm -f {combined_file}")
+            shell(f"cp {combined_file} {{output.combined}} >> " + str(log) + " 2>&1")
+            shell(f"rm -f {combined_file} >> " + str(log) + " 2>&1")
             # cd-hit-est is not run, so no .clstr is produced.
             # Touch an empty sentinel so Snakemake dependency tracking still works.
             # The saturation_plot script detects an empty file and uses a fallback.
-            shell("touch {output.clstr}")
+            shell("touch {output.clstr} >> " + str(log) + " 2>&1")
         else:
             # Run cd-hit-est clustering with config parameters
             shell(f"cd-hit-est -d 0 -aS {{params.cluster_coverage}} -c {{params.cluster_identity}} "
                   f"-G 0 -g 1 -b 500 -r 1 "
                   f"-i {combined_file} -o {{output.combined}} "
-                  f"-M {{resources.mem_mb}} -T {{threads}}")
+                  f"-M {{resources.mem_mb}} -T {{threads}} >> " + str(log) + " 2>&1")
             
             # Clean up intermediate files
-            shell(f"rm -f {combined_file}")
+            shell(f"rm -f {combined_file} >> " + str(log) + " 2>&1")
         
         # Ensure file is fully written to disk before dependent jobs start
-        shell("sync")
+        shell("sync >> " + str(log) + " 2>&1")
         shell("sleep 2")

--- a/rules/lib_construct.smk
+++ b/rules/lib_construct.smk
@@ -31,6 +31,8 @@ rule repeatmasker_warmup:
     """
     output:
         sentinel=touch(f"{OUTDIR}/.repeatmasker_cache_ready")
+    log:
+        f"{OUTDIR}/.repeatmasker_warmup.log"
     threads: 1
     resources:
         mem_mb=32000,
@@ -39,6 +41,7 @@ rule repeatmasker_warmup:
         rep_spec=REPSPEC
     shell:
         """
+        exec > {log} 2>&1
         RM_SHARE=$(which RepeatMasker | sed 's|/bin/RepeatMasker$|/share/RepeatMasker|')
 
         # Warm up the general library cache if not already built
@@ -102,6 +105,8 @@ rule prep_genome:
         gen_prep="{OUTDIR}/{species}_EarlGrey/{species}.prep",
         gen_dict="{OUTDIR}/{species}_EarlGrey/{species}.dict",
         backup="{OUTDIR}/{species}_EarlGrey/{species}.bak.gz"
+    log:
+        "{OUTDIR}/{species}_EarlGrey/{species}.prep_genome.log"
     threads: 1
     resources:
         mem_mb=4000,
@@ -110,6 +115,7 @@ rule prep_genome:
         script_dir=SCRIPT_DIR
     shell:
         """
+        exec > {log} 2>&1
         # Create backup of original genome in output directory
         # Remove any existing .orig file first (in case of rerun with read-only permissions)
         rm -f {output.gen_prep}.orig
@@ -145,6 +151,8 @@ rule repeatmasker:
         _cache=f"{OUTDIR}/.repeatmasker_cache_ready"
     output:
         masked="{outdir}/{species}_EarlGrey/{species}_RepeatMasker/{species}.prep.masked"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_RepeatMasker/{species}.repeatmasker.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 64)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 64))
     resources:
         mem_mb=lambda wildcards, attempt: 16000 * attempt,
@@ -155,6 +163,7 @@ rule repeatmasker:
         rm_threads=lambda wildcards, threads: max(1, threads // 4)  # RepeatMasker -pa value (uses 4x this)
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         RepeatMasker -species {params.rep_spec} -no_is -lcambig -s -a \
@@ -168,6 +177,8 @@ rule repeatmasker_custom:
         _cache=f"{OUTDIR}/.repeatmasker_cache_ready"
     output:
         masked="{outdir}/{species}_EarlGrey/{species}_RepeatMasker/{species}.prep.masked"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_RepeatMasker/{species}.repeatmasker.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 64)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 64))
     resources:
         mem_mb=lambda wildcards, attempt: 16000 * attempt,
@@ -177,6 +188,7 @@ rule repeatmasker_custom:
         rm_threads=lambda wildcards, threads: max(1, threads // 4)  # RepeatMasker -pa value (uses 4x this)
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         RepeatMasker -lib $(realpath {input.lib}) -no_is -lcambig -s -a \
@@ -186,6 +198,8 @@ rule repeatmasker_custom:
 rule extract_repeatmasker_library:
     output:
         replib=f"{{outdir}}/{REPSPEC}.RepeatMasker.lib"
+    log:
+        f"{{outdir}}/{REPSPEC}.extract_repeatmasker_library.log"
     params:
         repspec=REPSPEC,
         outdir=OUTDIR
@@ -195,6 +209,7 @@ rule extract_repeatmasker_library:
         runtime=30
     shell:
         """
+        exec > {log} 2>&1
         # Determine RepeatMasker library path
         if [[ $(which RepeatMasker) == *"bin"* ]]; then
             libpath="$(which RepeatMasker | sed 's|bin/RepeatMasker|share/RepeatMasker/Libraries/famdb/|')"
@@ -217,6 +232,8 @@ rule build_db:
         db="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nhr",
         nin="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nin",
         nsq="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nsq"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_Database/{species}.build_db.log"
     threads: 1
     resources:
         mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -226,6 +243,7 @@ rule build_db:
         name="{species}"
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.outdir}
         cd {params.outdir}
         BuildDatabase -name {params.name} {input.masked}
@@ -235,9 +253,12 @@ rule repeatmodeler:
     input:
         db="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nhr",
         nin="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nin",
-        nsq="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nsq"
+        nsq="{outdir}/{species}_EarlGrey/{species}_Database/{species}.nsq",
+        prep="{outdir}/{species}_EarlGrey/{species}.prep"
     output:
         families="{outdir}/{species}_EarlGrey/{species}_Database/{species}-families.fa"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_RepeatModeler/{species}.repeatmodeler.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 64)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 64))
     resources:
         mem_mb=lambda wildcards, attempt: 32000 * attempt,
@@ -248,20 +269,39 @@ rule repeatmodeler:
         db_name="{species}"
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.rm_dir}
         cd {params.rm_dir}
 
-        # Check genome size; small genomes can fail in later RepeatModeler rounds
-        # because there are insufficient unmasked bases to generate a sample.
-        # -genomeSampleSizeMax caps the sample to the actual genome size.
-        GENOME_SIZE=$(blastdbcmd -db {params.db_dir}/{params.db_name} -info 2>/dev/null | \
-            grep "total bases" | sed 's/.*[; ]\([0-9,]*\) total bases.*/\1/' | tr -d ',')
+        # Compute sampable genome size: sum of contigs >= 40 kb only.
+        # RepeatModeler discards contigs shorter than 40 kb during sampling, so using
+        # the total genome size would overestimate the sequence available per round.
+        GENOME_SIZE=$(awk '/^>/{{if(len>=40000)sum+=len; len=0; next}}{{len+=length($0)}} END{{if(len>=40000)sum+=len; print sum+0}}' {input.prep})
+        echo "Samplable genome size (contigs >= 40 kb): $GENOME_SIZE bp"
+
+        # Set -genomeSampleSizeMax to the highest RECON round threshold the genome
+        # can support. Thresholds are cumulative across rounds (r2=3M, r3=9M, r4=27M,
+        # r5=81M, r6=243M), so the sampable size must cover all rounds up to the cap:
+        #   >= 363M (3+9+27+81+243): no cap  -> all 6 rounds
+        #   >= 120M (3+9+27+81):     cap 81M  -> rounds 1-5
+        #   >=  39M (3+9+27):        cap 27M  -> rounds 1-4
+        #   >=  12M (3+9):           cap  9M  -> rounds 1-3
+        #   <   12M:                 cap  3M  -> rounds 1-2
         SAMPLE_FLAG=""
-        if [ -n "$GENOME_SIZE" ] && echo "$GENOME_SIZE" | grep -qE '^[0-9]+$'; then
-            if [ "$GENOME_SIZE" -lt 81000000 ]; then
-                echo "Small genome detected ($GENOME_SIZE bp): setting -genomeSampleSizeMax $GENOME_SIZE" >&2
-                SAMPLE_FLAG="-genomeSampleSizeMax $GENOME_SIZE"
-            fi
+        if [ "$GENOME_SIZE" -ge 363000000 ] 2>/dev/null; then
+            : # genome large enough for all rounds; use RepeatModeler default
+        elif [ "$GENOME_SIZE" -ge 120000000 ] 2>/dev/null; then
+            echo "Capping at round 5 (-genomeSampleSizeMax 81000000)"
+            SAMPLE_FLAG="-genomeSampleSizeMax 81000000"
+        elif [ "$GENOME_SIZE" -ge 39000000 ] 2>/dev/null; then
+            echo "Capping at round 4 (-genomeSampleSizeMax 27000000)"
+            SAMPLE_FLAG="-genomeSampleSizeMax 27000000"
+        elif [ "$GENOME_SIZE" -ge 12000000 ] 2>/dev/null; then
+            echo "Capping at round 3 (-genomeSampleSizeMax 9000000)"
+            SAMPLE_FLAG="-genomeSampleSizeMax 9000000"
+        else
+            echo "Capping at round 2 (-genomeSampleSizeMax 3000000)"
+            SAMPLE_FLAG="-genomeSampleSizeMax 3000000"
         fi
 
         RepeatModeler -threads {threads} -database {params.db_dir}/{params.db_name} $SAMPLE_FLAG
@@ -274,6 +314,8 @@ rule testrainer:
     output:
         strained="{outdir}/{species}_EarlGrey/{species}_strainer/{species}-families.fa.strained",
         summary="{outdir}/{species}_EarlGrey/{species}_summaryFiles/{species}-families.fa.strained"
+    log:
+        "{outdir}/{species}_EarlGrey/{species}_strainer/{species}.testrainer.log"
     threads: lambda wildcards: max(1, min(workflow.cores, 64)) if config.get("slurm_mode", False) else max(1, min(workflow.cores // len(SPECIES_LIST), 64))
     resources:
         mem_mb=lambda wildcards, attempt: config.get("total_memory_mb", 32000 * attempt),
@@ -288,6 +330,7 @@ rule testrainer:
         strainer_dir="{outdir}/{species}_EarlGrey/{species}_strainer"
     shell:
         """
+        exec > {log} 2>&1
         mkdir -p {params.strainer_dir}
         cd {params.strainer_dir}
         {params.script_dir}/TEstrainer/TEstrainer_for_earlGrey.sh \

--- a/rules/lib_construct.smk
+++ b/rules/lib_construct.smk
@@ -20,28 +20,68 @@ elif REPSPEC:
 
 rule repeatmasker_warmup:
     """
-    Pre-build the RepeatMasker general library BLAST cache before parallel genome
-    jobs start. On a freshly configured conda environment, the cache does not yet
-    exist. Running multiple RepeatMasker processes simultaneously causes a race
-    where each tries to write the same cache directory and all but one fail.
-    Running a single warmup job first ensures the cache is in place so that all
-    parallel RepeatMasker jobs can proceed without conflict.
+    Pre-build the RepeatMasker general and species-specific library BLAST caches
+    before parallel genome jobs start. On a freshly configured conda environment,
+    the caches do not yet exist. Running multiple RepeatMasker processes
+    simultaneously causes a race where each tries to write the same cache
+    directory and all but one fail. Running a single warmup job first ensures
+    both caches are fully in place (including refineableHash.dat and
+    speciesMeta.pm) so that all parallel RepeatMasker jobs can proceed without
+    conflict.
     """
     output:
         sentinel=touch(f"{OUTDIR}/.repeatmasker_cache_ready")
     threads: 1
     resources:
-        mem_mb=4000,
-        runtime=30
+        mem_mb=32000,
+        runtime=120
+    params:
+        rep_spec=REPSPEC
     shell:
         """
         RM_SHARE=$(which RepeatMasker | sed 's|/bin/RepeatMasker$|/share/RepeatMasker|')
+
+        # Warm up the general library cache if not already built
         if ! find "$RM_SHARE/Libraries" -maxdepth 2 -type d -name "general" 2>/dev/null | grep -q .; then
             echo "Warming up RepeatMasker general library cache..." >&2
             tmp=$(mktemp -d)
             printf '>dummy\\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\\n' > "$tmp/dummy.fa"
             RepeatMasker -lib "$tmp/dummy.fa" -no_is -pa 1 -dir "$tmp" "$tmp/dummy.fa" > /dev/null 2>&1 || true
             rm -rf "$tmp"
+        fi
+
+        # Warm up the species-specific library cache if a species is specified
+        # This prevents a race condition where parallel jobs all try to build
+        # the same species cache (including refineableHash.dat / speciesMeta.pm)
+        # simultaneously, causing all but one to fail.
+        if [ -n "{params.rep_spec}" ]; then
+            SPECIES_WORD=$(echo "{params.rep_spec}" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
+            CACHE_PARENT="$RM_SHARE/Libraries/CONS-Dfam_withRBRM_3.9"
+            CACHE_DIR="$CACHE_PARENT/$SPECIES_WORD"
+
+            # If the cache directory exists but refineableHash.dat is missing, it is
+            # incomplete (e.g. a previous OOM-killed makeblastdb run). RepeatMasker
+            # considers *.nhr sufficient to skip rebuilding, so we must delete the
+            # incomplete directory to force a fresh build.
+            if [ -d "$CACHE_DIR" ] && [ ! -f "$CACHE_DIR/refineableHash.dat" ]; then
+                echo "Incomplete species cache detected (missing refineableHash.dat). Removing $CACHE_DIR to force rebuild..." >&2
+                rm -rf "$CACHE_DIR"
+            fi
+            # Also remove any stale .working directory left by a previous aborted run.
+            rm -rf "$CACHE_DIR.working" 2>/dev/null || true
+
+            if [ ! -f "$CACHE_DIR/refineableHash.dat" ]; then
+                echo "Warming up RepeatMasker species library cache for {params.rep_spec}..." >&2
+                tmp=$(mktemp -d)
+                printf '>dummy\\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\\n' > "$tmp/dummy.fa"
+                RepeatMasker -species "{params.rep_spec}" -no_is -pa 1 -dir "$tmp" "$tmp/dummy.fa" > /dev/null 2>&1 || true
+                rm -rf "$tmp"
+                if [ ! -f "$CACHE_DIR/refineableHash.dat" ]; then
+                    echo "ERROR: species cache build failed — refineableHash.dat still missing in $CACHE_DIR" >&2
+                    exit 1
+                fi
+                echo "Species cache built successfully." >&2
+            fi
         fi
         """
 
@@ -210,7 +250,21 @@ rule repeatmodeler:
         """
         mkdir -p {params.rm_dir}
         cd {params.rm_dir}
-        RepeatModeler -threads {threads} -database {params.db_dir}/{params.db_name}
+
+        # Check genome size; small genomes can fail in later RepeatModeler rounds
+        # because there are insufficient unmasked bases to generate a sample.
+        # -genomeSampleSizeMax caps the sample to the actual genome size.
+        GENOME_SIZE=$(blastdbcmd -db {params.db_dir}/{params.db_name} -info 2>/dev/null | \
+            grep "total bases" | sed 's/.*[; ]\([0-9,]*\) total bases.*/\1/' | tr -d ',')
+        SAMPLE_FLAG=""
+        if [ -n "$GENOME_SIZE" ] && echo "$GENOME_SIZE" | grep -qE '^[0-9]+$'; then
+            if [ "$GENOME_SIZE" -lt 81000000 ]; then
+                echo "Small genome detected ($GENOME_SIZE bp): setting -genomeSampleSizeMax $GENOME_SIZE" >&2
+                SAMPLE_FLAG="-genomeSampleSizeMax $GENOME_SIZE"
+            fi
+        fi
+
+        RepeatModeler -threads {threads} -database {params.db_dir}/{params.db_name} $SAMPLE_FLAG
         """
 
 rule testrainer:

--- a/rules/lib_construct.smk
+++ b/rules/lib_construct.smk
@@ -40,7 +40,7 @@ rule repeatmasker_warmup:
             echo "Warming up RepeatMasker general library cache..." >&2
             tmp=$(mktemp -d)
             printf '>dummy\\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\\n' > "$tmp/dummy.fa"
-            RepeatMasker -lib "$tmp/dummy.fa" -norna -no_is -pa 1 -dir "$tmp" "$tmp/dummy.fa" > /dev/null 2>&1 || true
+            RepeatMasker -lib "$tmp/dummy.fa" -no_is -pa 1 -dir "$tmp" "$tmp/dummy.fa" > /dev/null 2>&1 || true
             rm -rf "$tmp"
         fi
         """
@@ -117,7 +117,7 @@ rule repeatmasker:
         """
         mkdir -p {params.outdir}
         cd {params.outdir}
-        RepeatMasker -species {params.rep_spec} -norna -no_is -lcambig -s -a \
+        RepeatMasker -species {params.rep_spec} -no_is -lcambig -s -a \
             -pa {params.rm_threads} -dir {params.outdir} $(realpath {input.genome})
         """
 
@@ -139,7 +139,7 @@ rule repeatmasker_custom:
         """
         mkdir -p {params.outdir}
         cd {params.outdir}
-        RepeatMasker -lib $(realpath {input.lib}) -norna -no_is -lcambig -s -a \
+        RepeatMasker -lib $(realpath {input.lib}) -no_is -lcambig -s -a \
             -pa {params.rm_threads} -dir {params.outdir} $(realpath {input.genome})
         """
 

--- a/rules/saturation.smk
+++ b/rules/saturation.smk
@@ -20,6 +20,8 @@ rule saturation_plot:
     output:
         plot=f"{OUTDIR}/combinedLibraries/saturation_plot.pdf",
         table=f"{OUTDIR}/combinedLibraries/saturation_data.tsv",
+    log:
+        f"{OUTDIR}/combinedLibraries/saturation_plot.log"
     threads: 1
     resources:
         mem_mb=4000,

--- a/rules/shared_unique_content.smk
+++ b/rules/shared_unique_content.smk
@@ -43,6 +43,8 @@ if PIPELINE_MODE == "full" and not RUN_BUSCO_PHYLO:
             fam_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_families.tsv",
             cov_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.pdf",
             cov_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.tsv",
+        log:
+            f"{OUTDIR}/sharedUniqueContent/shared_unique_plot.log"
         threads: 1
         resources:
             mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -76,6 +78,8 @@ elif PIPELINE_MODE == "full" and RUN_BUSCO_PHYLO:
             cov_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.tsv",
             fam_phylo_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_families_phylo.pdf",
             cov_phylo_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage_phylo.pdf",
+        log:
+            f"{OUTDIR}/sharedUniqueContent/shared_unique_plot.log"
         threads: 1
         resources:
             mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -105,6 +109,8 @@ elif PIPELINE_MODE == "annotate" and not RUN_BUSCO_PHYLO:
             fam_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_families.tsv",
             cov_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.pdf",
             cov_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.tsv",
+        log:
+            f"{OUTDIR}/sharedUniqueContent/shared_unique_plot.log"
         threads: 1
         resources:
             mem_mb=lambda wildcards, attempt: 8000 * attempt,
@@ -137,6 +143,8 @@ elif PIPELINE_MODE == "annotate" and RUN_BUSCO_PHYLO:
             cov_tsv=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage.tsv",
             fam_phylo_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_families_phylo.pdf",
             cov_phylo_pdf=f"{OUTDIR}/sharedUniqueContent/shared_unique_coverage_phylo.pdf",
+        log:
+            f"{OUTDIR}/sharedUniqueContent/shared_unique_plot.log"
         threads: 1
         resources:
             mem_mb=lambda wildcards, attempt: 8000 * attempt,

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -199,7 +199,7 @@ busco_min_occupancy: 0.5  # Min fraction of species a gene must appear in (0.0-1
 # script_dir: "/path/to/earlgrey/scripts"  # Auto-detected if installed via conda/mamba
 
 # SLURM cluster settings (only used with --slurm flag)
-slurm_partition: ""   # partition/queue to submit to (required with --slurm)
+slurm_partition: ""   # partition/queue to submit to (required when using --slurm; can be set here instead of --slurm-partition)
 slurm_account: ""     # account string (leave empty if not required)
 slurm_extra: ""       # any extra sbatch flags, e.g. "--constraint=avx2"
 """
@@ -263,7 +263,7 @@ busco_min_occupancy: 0.5
 # script_dir: "/path/to/earlgrey/scripts"  # Auto-detected if installed via conda/mamba
 
 # SLURM cluster settings (only used with --slurm flag)
-slurm_partition: ""   # partition/queue to submit to (required with --slurm)
+slurm_partition: ""   # partition/queue to submit to (required when using --slurm; can be set here instead of --slurm-partition)
 slurm_account: ""     # account string (leave empty if not required)
 slurm_extra: ""       # any extra sbatch flags, e.g. "--constraint=avx2"
 """
@@ -321,7 +321,7 @@ busco_min_occupancy: 0.5  # Min fraction of species a gene must appear in (0.0-1
 # script_dir: "/path/to/earlgrey/scripts"  # Auto-detected if installed via conda/mamba
 
 # SLURM cluster settings (only used with --slurm flag)
-slurm_partition: ""   # partition/queue to submit to (required with --slurm)
+slurm_partition: ""   # partition/queue to submit to (required when using --slurm; can be set here instead of --slurm-partition)
 slurm_account: ""     # account string (leave empty if not required)
 slurm_extra: ""       # any extra sbatch flags, e.g. "--constraint=avx2"
 """


### PR DESCRIPTION
This pull request releases version 0.1.7 of the ParTEA pipeline, introducing major improvements in logging, robustness for small genomes, RepeatMasker cache handling, and TE annotation completeness. It also updates documentation and configuration to reflect these changes. Below are the most important updates:

**Pipeline robustness and correctness:**

* The pipeline now automatically computes the samplable genome size (contigs ≥ 40 kb) and sets `-genomeSampleSizeMax` for RepeatModeler to prevent crashes on small or fragmented genomes. This ensures only feasible rounds are run based on available sequence. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R111) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1002-R1029) [[3]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7L2072-R2255)
* The `repeatmasker_warmup` rule is extended to pre-build species-specific BLAST caches serially, preventing parallel build failures and detecting incomplete caches from previous failed runs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R111) [[2]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7L2072-R2255)

**Annotation completeness:**

* The `-norna` flag is removed from all RepeatMasker calls, ensuring RNA-derived repeats (e.g., SINEs, snRNA, tRNA) are included in TE annotations for more comprehensive results. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R111) [[2]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7L2072-R2255)

**Logging and debugging improvements:**

* Every rule now writes tool output to a dedicated per-rule log file alongside its output directory. Only Snakemake progress messages are printed to the terminal, making post-run debugging much easier. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R111) [[2]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7L2072-R2255)
* Fixed a wildcard mismatch bug in `clustering.smk` by ensuring `log:` directives use Snakemake wildcards, not Python f-strings.

**Documentation and configuration:**

* The `README.md` and `docs/developmentNotes.md` are updated to describe all new features, troubleshooting steps, and verification checklists for v0.1.7. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R111) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L892-R929) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1002-R1029) [[4]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7L2072-R2255)
* The SLURM partition config and help text are clarified to allow setting the partition via the config file or CLI. [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaL77-R77) [[2]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cL40-R41) [[3]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cL354-R355)

**Versioning and release:**

* All version numbers are bumped from 0.1.6 to 0.1.7 in scripts, conda recipe, and documentation. [[1]](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cL2-R10) [[2]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cL4-R9) [[3]](diffhunk://#diff-a8a329cf71e149731c75ba7fb5f07372a84bb032af18df368cb39cb6c8f66654L4-R9) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R144)

These changes make the pipeline more robust, easier to debug, and produce more complete TE annotations.