### PR TITLE
updates to clustering behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,73 +66,43 @@ ParTEA extends EarlGrey with features designed for multi-genome comparative TE a
 - 🌳 **BUSCO Phylogenomics** *(new in v0.1.6)* — Optional module (`run_busco_phylo: true`) that runs BUSCO, aligns and trims single-copy orthologues, concatenates a supermatrix, and infers a species tree with FastTree. Outputs a phylo-ordered BUSCO completeness chart with cladogram sidebar and a TE content vs BUSCO QC scatter plot.
 - 📋 **Per-rule log files** *(new in v0.1.7)* — Every rule now writes its tool output to a dedicated log file placed alongside its output directory. Only Snakemake progress messages are printed to the terminal during a run; all RepeatMasker, RepeatModeler, HELIANO, and other tool output is captured in per-rule logs for easier post-hoc debugging.
 - 🛡️ **RepeatModeler small-genome robustness** *(improved in v0.1.7)* — The pipeline now computes the samplable genome size (contigs ≥ 40 kb only) and automatically sets `-genomeSampleSizeMax` to prevent RepeatModeler from attempting a round for which insufficient unmasked sequence remains. See [Troubleshooting](#troubleshooting) for details.
+- 🔧 **RepeatMasker cache-directory compatibility** *(improved in v0.1.8)* — The species-library warmup now discovers the `CONS-*` cache directory dynamically rather than hardcoding `CONS-Dfam_withRBRM_3.9`. This fixes a failure on installations configured with Dfam only (no RepBase), where the directory has a different name.
 
 ---
 
-## 🆕 Changes in Latest Release (v0.1.7)
+## 🆕 Changes in Latest Release (v0.1.8)
+
+### Dynamic discovery of RepeatMasker species-library cache directory
+
+The `repeatmasker_warmup` rule previously hardcoded the species-library BLAST cache parent as `CONS-Dfam_withRBRM_3.9`. This path only exists on installations that include both Dfam and RepBase RepeatMasker edition. On Dfam-only installations the directory has a different name (e.g. `CONS-Dfam_3.9`), causing the warmup to check the wrong location and fail to validate the cache before parallel genome jobs started.
+
+The path is now discovered dynamically:
+
+```bash
+CACHE_PARENT=$(find "$RM_SHARE/Libraries" -maxdepth 1 -type d -name "CONS-*" 2>/dev/null | head -n 1)
+```
+
+If no `CONS-*` directory is found, the warmup prints a clear warning and exits gracefully rather than crashing.
+
+---
+
+## Previous Release (v0.1.7)
 
 ### Per-rule log files
 
 All rules across all six rule files now write their tool output to a dedicated log file placed alongside the relevant output directory (e.g. `{species}.repeatmodeler.log` next to `{species}_RepeatModeler/`). Only Snakemake's own job progress messages are printed to the terminal during a run.
 
-This makes it much easier to locate warnings or diagnose failures after a run without scrolling through thousands of lines of mixed terminal output.
-
 ### RepeatModeler small-genome robustness
 
-RepeatModeler can crash on small or fragmented genomes when a later round tries to sample more sequence than is available. The pipeline now prevents this by:
-
-1. Computing the **samplable genome size** — the sum of all contig lengths ≥ 40 kb (RepeatModeler discards shorter contigs during sampling, so the total genome size overestimates what is available).
-2. Setting `-genomeSampleSizeMax` to the per-round sample size for the highest RECON round the genome can support, based on cumulative sample totals across rounds:
-
-| Samplable size | `-genomeSampleSizeMax` | Rounds run |
-|---|---|---|
-| ≥ 363 Mbp | none (default) | 1–6 |
-| ≥ 120 Mbp | `81000000` | 1–5 |
-| ≥ 39 Mbp | `27000000` | 1–4 |
-| ≥ 12 Mbp | `9000000` | 1–3 |
-| < 12 Mbp | `3000000` | 1–2 |
+RepeatModeler can crash on small or fragmented genomes when a later round tries to sample more sequence than is available. The pipeline now prevents this by computing the **samplable genome size** (contigs ≥ 40 kb only) and setting `-genomeSampleSizeMax` to the appropriate per-round cap.
 
 ### Extended `repeatmasker_warmup` — species-specific cache
 
-When `repeatmasker_species` is set, RepeatMasker must build a species-specific BLAST database cache before any genome jobs start. Previously this cache was built by the first parallel genome job; if multiple jobs started simultaneously each would attempt to build it and all but one would fail. The warmup rule now pre-builds this cache serially before any per-genome jobs are dispatched.
-
-The warmup also detects and repairs incomplete caches left by a previous OOM-killed run (which can cause all subsequent jobs to crash even though the BLAST database files appear to exist).
+When `repeatmasker_species` is set, the warmup rule now pre-builds the species-specific BLAST database cache serially before any per-genome jobs are dispatched, preventing a race condition when multiple genome jobs start simultaneously. It also detects and repairs incomplete caches left by a previous OOM-killed run.
 
 ### Removal of `-norna` flag
 
-The `-norna` flag was removed from all RepeatMasker calls. This flag suppressed masking of RNA-derived repeats (snRNA, scRNA, tRNA, SINEs); removing it ensures these legitimate TE families are included in the annotation.
-
----
-
-## Previous Release (v0.1.6)
-
-### New optional modules
-
-Two new analysis modules were added (both disabled by default):
-
-| Module | Config key | Description |
-|--------|-----------|-------------|
-| Shared/Unique TE Content | `run_shared_unique: true` | Stacked bar charts showing the proportion of TE families (or genome coverage) that are shared across all genomes, shared among subsets, or unique to each genome. Optionally reordered by phylogeny. |
-| BUSCO Phylogenomics | `run_busco_phylo: true` | Runs BUSCO, builds a single-copy orthologue supermatrix, infers a species tree with FastTree, and produces a completeness bar chart ordered along the tree. A TE content vs BUSCO completeness QC scatter plot is also generated. |
-
-See [Optional Analysis Modules](#-optional-analysis-modules) for full documentation.
-
-### Extended config generation
-
-Three new flags make it easier to create config files without manual editing:
-
-| Flag | Description |
-|------|-------------|
-| `--genome-dir DIR` | Scan a directory for FASTA files and auto-populate `genome:` / `species:` blocks |
-| `--from-csv FILE` | Read a CSV with `species` and `genome_path` columns to populate the config |
-| `--output-dir DIR` | Set `output_dir` in the generated config (usable with either flag above) |
-
-The CSV format requires two columns (`species`, `genome_path`); `output_dir` is
-always supplied on the command line, not inside the CSV.
-
-All three pipeline entry points (`earlGreyParTEA`, `earlGreyParTEA_LibConstruct`,
-`earlGreyParTEA_AnnotationOnly`) support the new flags. The blank-template
-behaviour of `--generate-config` is unchanged.
+The `-norna` flag was removed from all RepeatMasker calls, ensuring RNA-derived repeats (snRNA, scRNA, tRNA, SINEs) are included in the annotation.
 
 ---
 
@@ -141,7 +111,7 @@ behaviour of `--generate-config` is unchanged.
 - [What is ParTEA?](#what-is-partea)
 - [Citation](#-citation)
 - [ParTEA Features](#-partea-features)
-- [Changes in Latest Release](#-changes-in-latest-release-v017)
+- [Changes in Latest Release](#-changes-in-latest-release-v018)
 - [Pipeline Overview](#-pipeline-overview)
 - [Installation](#-installation)
   - [Via conda/mamba](#via-condamamba-recommended---party-in-a-package)

--- a/README.md
+++ b/README.md
@@ -67,10 +67,23 @@ ParTEA extends EarlGrey with features designed for multi-genome comparative TE a
 - 📋 **Per-rule log files** *(new in v0.1.7)* — Every rule now writes its tool output to a dedicated log file placed alongside its output directory. Only Snakemake progress messages are printed to the terminal during a run; all RepeatMasker, RepeatModeler, HELIANO, and other tool output is captured in per-rule logs for easier post-hoc debugging.
 - 🛡️ **RepeatModeler small-genome robustness** *(improved in v0.1.7)* — The pipeline now computes the samplable genome size (contigs ≥ 40 kb only) and automatically sets `-genomeSampleSizeMax` to prevent RepeatModeler from attempting a round for which insufficient unmasked sequence remains. See [Troubleshooting](#troubleshooting) for details.
 - 🔧 **RepeatMasker cache-directory compatibility** *(improved in v0.1.8)* — The species-library warmup now discovers the `CONS-*` cache directory dynamically rather than hardcoding `CONS-Dfam_withRBRM_3.9`. This fixes a failure on installations configured with Dfam only (no RepBase), where the directory has a different name.
+- 📏 **CD-HIT length-difference cutoff** *(new in v0.1.8)* — A new `clustering_length_diff` parameter (default `0.5`) passes the `-s` flag to `cd-hit-est`, preventing sequences that are less than half the length of the cluster representative from being grouped together. This avoids biologically misleading clusters where small partial elements are merged with full-length copies.
 
 ---
 
 ## 🆕 Changes in Latest Release (v0.1.8)
+
+### CD-HIT length-difference cutoff
+
+Previously, `cd-hit-est` was run with `-aS` (alignment coverage of the shorter sequence) and `-G 0` (local alignment mode) but no constraint on the *length ratio* between sequences. Under these settings a short partial element (e.g. 1 000 nt) could be clustered with a full-length copy (e.g. 20 000 nt) as long as 80 % of the short sequence aligned somewhere within the long one. This produces clusters that span a ~20-fold length range, potentially merging biologically distinct elements.
+
+A new `clustering_length_diff` parameter (default `0.5`) is now passed to `cd-hit-est` as the `-s` flag. The shorter sequence must be at least this fraction of the longer sequence's length to be placed in the same cluster. At the default value of `0.5`, sequences must be within a 2× length ratio — eliminating the most extreme mismatches while still allowing partial elements from the same family to cluster together.
+
+The parameter is fully configurable via `config.yaml`:
+
+```yaml
+clustering_length_diff: 0.5  # 0.0 = no limit; 1.0 = identical lengths only
+```
 
 ### Dynamic discovery of RepeatMasker species-library cache directory
 
@@ -518,10 +531,13 @@ custom_library: "/path/to/lib.fa"   # Use custom library
 ### Clustering Options
 
 ```yaml
-skip_clustering: false     # Set true to skip clustering
-clustering_identity: 0.8   # cd-hit identity threshold (0.0-1.0)
-clustering_coverage: 0.8   # cd-hit coverage threshold (0.0-1.0)
+skip_clustering: false       # Set true to skip clustering
+clustering_identity: 0.8     # cd-hit identity threshold (0.0-1.0)
+clustering_coverage: 0.8     # cd-hit coverage threshold (0.0-1.0)
+clustering_length_diff: 0.5  # cd-hit -s: shorter seq >= this fraction of longer (0.0 = no limit)
 ```
+
+`clustering_length_diff` prevents sequences of very different sizes from being merged into the same cluster. At the default of `0.5` the shorter sequence must be at least half the length of the cluster representative. Set to `0.0` to restore the previous behaviour (no length restriction).
 
 ### Output Options
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "earlgrey-partea" %}
-{% set version = "0.1.7" %}
+{% set version = "0.1.8" %}
 
 package:
   name: {{ name|lower }}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,6 +33,7 @@ min_consensus_seqs: 3   # Min sequences required for consensus
 skip_clustering: false          # Set to true to skip clustering (just concatenate)
 clustering_identity: 0.8        # cd-hit sequence identity threshold (0.0-1.0)
 clustering_coverage: 0.8        # cd-hit alignment coverage (0.0-1.0)
+clustering_length_diff: 0.5     # cd-hit -s: shorter seq must be >= this fraction of longer (0.0 = no limit)
 
 # Output options
 softmask: false         # Generate softmasked genome for each input

--- a/docs/developmentNotes.md
+++ b/docs/developmentNotes.md
@@ -2253,3 +2253,27 @@ log: "{outdir}/combinedLibraries/cluster_all_species.log"
 - [ ] Confirm `{OUTDIR}/combinedLibraries/cluster_all_species.log` is created on a multi-genome run (validates the wildcard-string fix).
 - [ ] Local mode regression: confirm all changes do not break a standard local run on a previously working dataset.
 
+## Release v0.1.8 Feature Updates
+
+### Dynamic discovery of RepeatMasker species-library cache directory
+
+**Problem:** The `repeatmasker_warmup` rule hardcoded the species-library BLAST cache parent directory as `$RM_SHARE/Libraries/CONS-Dfam_withRBRM_3.9`. This path is only present when the RepeatMasker installation includes both Dfam **and** RepBase RepeatMasker edition (RBRMSK). Users who configured RepeatMasker with Dfam only (or a future Dfam version with a different suffix) have a differently-named directory (e.g. `CONS-Dfam_3.9`). In those environments the warmup checked and rebuilt the cache in the wrong location — the real cache directory was never validated before the parallel genome jobs started.
+
+**Fix:** The hardcoded `CACHE_PARENT` assignment is replaced by a `find` call that discovers the actual `CONS-*` directory at runtime:
+
+```bash
+CACHE_PARENT=$(find "$RM_SHARE/Libraries" -maxdepth 1 -type d -name "CONS-*" 2>/dev/null | head -n 1)
+```
+
+This executes after the general-library warmup (which ensures the `Libraries/` directory is fully populated), so the `CONS-*` directory will exist by the time `find` runs if any species library is present. If no matching directory is found the warmup prints a clear warning and exits gracefully (exit 0) rather than attempting to validate a cache inside a non-existent parent.
+
+**Files changed:**
+- `rules/lib_construct.smk` — hardcoded `CACHE_PARENT` path replaced with dynamic `find` discovery; added graceful exit with warning if no `CONS-*` directory is found
+
+---
+
+### Verification checklist for v0.1.8
+
+- [ ] Run pipeline with `repeatmasker_species` set on an installation configured with Dfam **only** (no RepBase). Confirm warmup locates the `CONS-Dfam_*` directory and validates/builds the species cache correctly.
+- [ ] Run pipeline on a standard installation with both Dfam and RepBase. Confirm existing behaviour is unchanged.
+- [ ] Confirm that if the `Libraries/` directory contains no `CONS-*` subdirectory the warmup prints the expected warning and the pipeline does not proceed with species-cache validation.

--- a/docs/developmentNotes.md
+++ b/docs/developmentNotes.md
@@ -2255,6 +2255,23 @@ log: "{outdir}/combinedLibraries/cluster_all_species.log"
 
 ## Release v0.1.8 Feature Updates
 
+### CD-HIT length-difference cutoff for clustering (`clustering_length_diff`)
+
+**Problem:** The `cd-hit-est` command was invoked with `-aS` (alignment coverage of the shorter sequence) and `-G 0` (local alignment mode) but no constraint on the *length ratio* between sequences. Under these settings a small partial TE consensus (e.g. 1 000 nt) could be placed in the same cluster as a full-length copy (e.g. 20 000 nt) provided ~80 % of the short sequence aligned somewhere within the long one. Clusters spanning a 10–20× length range can merge biologically distinct elements (e.g. an LTR solo with a complete LTR retrotransposon) and produce misleading cluster representatives.
+
+**Fix:** A new `clustering_length_diff` parameter is exposed in `config.yaml` (default `0.5`) and passed to `cd-hit-est` as the `-s` flag. This requires the shorter sequence to be at least this fraction of the longer sequence's length before clustering is allowed. At the default value of `0.5`, sequences must be within a 2× length ratio — removing the most extreme mismatches while still permitting partial elements from the same family to cluster.
+
+Set to `0.0` to restore the previous behaviour (no length restriction).
+
+**Files changed:**
+- `config/config.yaml` — new `clustering_length_diff: 0.5` parameter
+- `rules/clustering.smk` — `cluster_length_diff` param added; `-s {params.cluster_length_diff}` added to `cd-hit-est` call
+- `scripts/on_start_functions.py` — default added to `validate_parameters`; startup message updated to include `length_diff`
+- `earlGreyParTEA`, `earlGreyParTEA_LibConstruct`, `earlGreyParTEA_AnnotationOnly` — `clustering_length_diff: 0.5` added to generated config templates
+- `README.md` — v0.1.8 section updated; Clustering Options docs updated
+
+---
+
 ### Dynamic discovery of RepeatMasker species-library cache directory
 
 **Problem:** The `repeatmasker_warmup` rule hardcoded the species-library BLAST cache parent directory as `$RM_SHARE/Libraries/CONS-Dfam_withRBRM_3.9`. This path is only present when the RepeatMasker installation includes both Dfam **and** RepBase RepeatMasker edition (RBRMSK). Users who configured RepeatMasker with Dfam only (or a future Dfam version with a different suffix) have a differently-named directory (e.g. `CONS-Dfam_3.9`). In those environments the warmup checked and rebuilt the cache in the wrong location — the real cache directory was never validated before the parallel genome jobs started.
@@ -2277,3 +2294,7 @@ This executes after the general-library warmup (which ensures the `Libraries/` d
 - [ ] Run pipeline with `repeatmasker_species` set on an installation configured with Dfam **only** (no RepBase). Confirm warmup locates the `CONS-Dfam_*` directory and validates/builds the species cache correctly.
 - [ ] Run pipeline on a standard installation with both Dfam and RepBase. Confirm existing behaviour is unchanged.
 - [ ] Confirm that if the `Libraries/` directory contains no `CONS-*` subdirectory the warmup prints the expected warning and the pipeline does not proceed with species-cache validation.
+- [ ] Run clustering on a multi-genome dataset and confirm that sequences with a length ratio > 2× (e.g. ~1 000 nt vs ~20 000 nt) are no longer grouped in the same cluster.
+- [ ] Confirm that setting `clustering_length_diff: 0.0` in the config restores the previous behaviour (no length restriction), and that sequences of very different sizes can still be clustered.
+- [ ] Confirm the startup summary prints `length_diff:` alongside `identity:` and `coverage:` when clustering is enabled.
+- [ ] Confirm `--generate-config` output from all three wrapper scripts includes `clustering_length_diff: 0.5`.

--- a/earlGreyParTEA
+++ b/earlGreyParTEA
@@ -110,6 +110,7 @@ min_consensus_seqs: 3   # Min sequences required for consensus
 skip_clustering: false          # Set to true to skip clustering (just concatenate)
 clustering_identity: 0.8        # cd-hit sequence identity threshold (0.0-1.0)
 clustering_coverage: 0.8        # cd-hit alignment coverage (0.0-1.0)
+clustering_length_diff: 0.5     # cd-hit -s: shorter seq must be >= this fraction of longer (0.0 = no limit)
 
 # Output options
 softmask: false         # Generate softmasked genome for each input

--- a/earlGreyParTEA
+++ b/earlGreyParTEA
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA - Pangenome TE Analysis Pipeline (Full Mode)
-# Version 0.1.7
+# Version 0.1.8
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e
 
-VERSION="0.1.7"
+VERSION="0.1.8"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/earlGreyParTEA_AnnotationOnly
+++ b/earlGreyParTEA_AnnotationOnly
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_AnnotationOnly - Pangenome TE Analysis Pipeline (Annotation Only Mode)
-# Version 0.1.7
+# Version 0.1.8
 # A Snakemake-based multi-genome transposable element annotation pipeline
 
 set -e
 
-VERSION="0.1.7"
+VERSION="0.1.8"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/earlGreyParTEA_AnnotationOnly
+++ b/earlGreyParTEA_AnnotationOnly
@@ -111,6 +111,7 @@ min_consensus_seqs: 3
 skip_clustering: false
 clustering_identity: 0.8
 clustering_coverage: 0.8
+clustering_length_diff: 0.5
 
 # Output options
 softmask: true          # Generate softmasked genome for each input

--- a/earlGreyParTEA_LibConstruct
+++ b/earlGreyParTEA_LibConstruct
@@ -114,6 +114,7 @@ min_consensus_seqs: 3   # Min sequences required for consensus
 skip_clustering: false          # Set to true to skip clustering (just concatenate)
 clustering_identity: 0.8        # cd-hit sequence identity threshold (0.0-1.0)
 clustering_coverage: 0.8        # cd-hit alignment coverage (0.0-1.0)
+clustering_length_diff: 0.5     # cd-hit -s: shorter seq must be >= this fraction of longer (0.0 = no limit)
 
 # Output options (not applicable in libconstruct mode)
 softmask: false

--- a/earlGreyParTEA_LibConstruct
+++ b/earlGreyParTEA_LibConstruct
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # earlGreyParTEA_LibConstruct - Pangenome TE Analysis Pipeline (Library Construction Mode)
-# Version 0.1.7
+# Version 0.1.8
 # A Snakemake-based multi-genome transposable element library construction pipeline
 
 set -e
 
-VERSION="0.1.7"
+VERSION="0.1.8"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {

--- a/rules/clustering.smk
+++ b/rules/clustering.smk
@@ -19,7 +19,8 @@ rule cluster_all_species:
         repspec=REPSPEC,
         skip_clustering=config.get("skip_clustering", False),
         cluster_identity=config.get("clustering_identity", 0.8),
-        cluster_coverage=config.get("clustering_coverage", 0.8)
+        cluster_coverage=config.get("clustering_coverage", 0.8),
+        cluster_length_diff=config.get("clustering_length_diff", 0.5)
     run:
         import os
         shell("mkdir -p {params.outdir}/combinedLibraries >> " + str(log) + " 2>&1")
@@ -68,7 +69,7 @@ rule cluster_all_species:
         else:
             # Run cd-hit-est clustering with config parameters
             shell(f"cd-hit-est -d 0 -aS {{params.cluster_coverage}} -c {{params.cluster_identity}} "
-                  f"-G 0 -g 1 -b 500 -r 1 "
+                  f"-s {{params.cluster_length_diff}} -G 0 -g 1 -b 500 -r 1 "
                   f"-i {combined_file} -o {{output.combined}} "
                   f"-M {{resources.mem_mb}} -T {{threads}} >> " + str(log) + " 2>&1")
             

--- a/rules/lib_construct.smk
+++ b/rules/lib_construct.smk
@@ -59,7 +59,13 @@ rule repeatmasker_warmup:
         # simultaneously, causing all but one to fail.
         if [ -n "{params.rep_spec}" ]; then
             SPECIES_WORD=$(echo "{params.rep_spec}" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')
-            CACHE_PARENT="$RM_SHARE/Libraries/CONS-Dfam_withRBRM_3.9"
+            # Dynamically discover the CONS cache parent — its name varies depending on
+            # whether RepBase is included (e.g. CONS-Dfam_withRBRM_3.9 vs CONS-Dfam_3.9).
+            CACHE_PARENT=$(find "$RM_SHARE/Libraries" -maxdepth 1 -type d -name "CONS-*" 2>/dev/null | head -n 1)
+            if [ -z "$CACHE_PARENT" ]; then
+                echo "WARNING: No CONS-* cache directory found under $RM_SHARE/Libraries — skipping species cache check." >&2
+                exit 0
+            fi
             CACHE_DIR="$CACHE_PARENT/$SPECIES_WORD"
 
             # If the cache directory exists but refineableHash.dat is missing, it is

--- a/scripts/on_start_functions.py
+++ b/scripts/on_start_functions.py
@@ -169,6 +169,7 @@ def validate_parameters(config, outfile = None):
         'skip_clustering': (False, None),
         'clustering_identity': (0.8, None),
         'clustering_coverage': (0.8, None),
+        'clustering_length_diff': (0.5, None),
         'softmask': (False, None),
         'margin': (False, None),
         'flank': (1000, "Blast, extend, align, trim process will add {}bp to each end in each iteration"),
@@ -220,7 +221,8 @@ def validate_parameters(config, outfile = None):
     else:
         cluster_id = config.get('clustering_identity', 0.8)
         cluster_cov = config.get('clustering_coverage', 0.8)
-        msg_info(f"TE consensus sequences will be clustered (identity: {cluster_id}, coverage: {cluster_cov})")
+        cluster_len = config.get('clustering_length_diff', 0.5)
+        msg_info(f"TE consensus sequences will be clustered (identity: {cluster_id}, coverage: {cluster_cov}, length_diff: {cluster_len})")
         msg_warn("Clustering may affect subfamilies and create chimeras")
 
     # Saturation plot


### PR DESCRIPTION
This pull request updates the ParTEA pipeline to version 0.1.8, introducing two major improvements: a configurable length-difference cutoff for TE clustering with CD-HIT, and dynamic discovery of the RepeatMasker species-library cache directory. These changes improve clustering accuracy and compatibility with various RepeatMasker installations. Documentation, configuration templates, and startup messages have been updated accordingly.

**Clustering improvements:**
- Added a new `clustering_length_diff` parameter (default `0.5`) to `config.yaml` and all config templates, controlling the minimum length ratio for clustering TE sequences with `cd-hit-est`. This prevents short partial elements from being merged with much longer sequences, improving biological accuracy. The parameter is passed to `cd-hit-est` as the `-s` flag, and is fully documented in the README and developer notes. [[1]](diffhunk://#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR36) [[2]](diffhunk://#diff-30351e4977331440c60f7202c50e908d9484ecff039cec56936d203c41d16bf5R117) [[3]](diffhunk://#diff-a8a329cf71e149731c75ba7fb5f07372a84bb032af18df368cb39cb6c8f66654R114) [[4]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cR113) [[5]](diffhunk://#diff-3c7bceec3367bdb788d2fee68f72783be3e2f2bf3637c6756da3b3526bc94673L22-R23) [[6]](diffhunk://#diff-3c7bceec3367bdb788d2fee68f72783be3e2f2bf3637c6756da3b3526bc94673L71-R72) [[7]](diffhunk://#diff-cad5a5abf5bf5f2ea60d1cb5817b5b7afd51f3a9e8d49295b71393ff00f0e3bcR172) [[8]](diffhunk://#diff-cad5a5abf5bf5f2ea60d1cb5817b5b7afd51f3a9e8d49295b71393ff00f0e3bcL223-R225) [[9]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7R2256-R2300) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R118) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R537-R541)

**RepeatMasker compatibility:**
- The RepeatMasker species-library cache directory is now discovered dynamically using a `find` command, instead of being hardcoded. This ensures compatibility with installations that have Dfam only, RepBase, or both. If no suitable directory is found, the pipeline prints a warning and exits gracefully. [[1]](diffhunk://#diff-1d877e24f153fc00b56b92629506e66111431c547a42fe54fd4fb9b7e7df3832L62-R68) [[2]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7R2256-R2300) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R118)

**Documentation and versioning:**
- Updated the README to reflect v0.1.8 changes, including new clustering options and RepeatMasker cache handling. The release notes and table of contents are revised. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L144-R127) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R537-R541) [[4]](diffhunk://#diff-64e8274dd5a9a6a26ddf62abc8e161af879d177b89adbbc47e281aa7aa201ca7R2256-R2300)
- Updated version numbers to 0.1.8 in all scripts and the conda recipe. [[1]](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cL2-R2) [[2]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cL4-R9) [[3]](diffhunk://#diff-65968d12f81f57973d1d534e253880c417002fb34759f5e5bddedcf76b0ca81cR113) [[4]](diffhunk://#diff-a8a329cf71e149731c75ba7fb5f07372a84bb032af18df368cb39cb6c8f66654L4-R9) [[5]](diffhunk://#diff-a8a329cf71e149731c75ba7fb5f07372a84bb032af18df368cb39cb6c8f66654R114) [[6]](diffhunk://#diff-30351e4977331440c60f7202c50e908d9484ecff039cec56936d203c41d16bf5L4-R9) [[7]](diffhunk://#diff-30351e4977331440c60f7202c50e908d9484ecff039cec56936d203c41d16bf5R117)

These updates make the pipeline more robust, easier to configure, and compatible with a wider range of environments.